### PR TITLE
Ensure container startup sequence

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,8 @@ FROM debian:bullseye
 
 RUN apt-get update && apt-get install -y \
 	nginx \
-	openssl
+	openssl \
+	netcat-traditional
 
 COPY tools/nginx.conf /etc/nginx/
 COPY tools/ssl.conf /etc/nginx/sites-available/default

--- a/frontend/tools/docker-entrypoint.sh
+++ b/frontend/tools/docker-entrypoint.sh
@@ -34,4 +34,22 @@ if [ ! -f /etc/nginx/ssl/server.key ] || [ ! -f /etc/nginx/ssl/server.crt ]; the
     openssl req -newkey rsa:2048 -x509 -nodes -days 365 -keyout /etc/nginx/ssl/server.key -out /etc/nginx/ssl/server.crt -config config.tmp
 fi
 
+echo "Waiting for backend booting..."
+for i in {30..0}; do
+    if nc -z backend 8001; then
+        echo "backend OK"
+	    break;
+    fi
+    sleep 1
+done
+
+echo "Waiting for pong-server booting..."
+for i in {30..0}; do
+    if nc -z pong-server 8002; then
+        echo "pong-server OK"
+	    break;
+    fi
+    sleep 1
+done
+
 exec "$@"


### PR DESCRIPTION
期待するコンテナの起動順序を確実にするため、waitするように変更

- 変更前では場合によりfrontend （nginx）の起動が先行してしまってbackendやpong-serverの名前解決でコケる可能性がある→nginxの設定読み込み時にエラーとなる