### PR TITLE
Include player name to JWT

### DIFF
--- a/backend/scandamus/game/match_utils.py
+++ b/backend/scandamus/game/match_utils.py
@@ -20,9 +20,9 @@ async def send_match_jwt(consumer, from_username, game_name='pong'):
     match = await create_match(player1, player2)
     
     for player in [player1, player2]:
-        game_token = await issue_jwt(player.user, player.id, match.id, game_name)
-        websocket = consumer.players.get(player.user.username)
         player_name = 'player1' if player == player1 else 'player2'
+        game_token = await issue_jwt(player.user, player_name, player.id, match.id, game_name)
+        websocket = consumer.players.get(player.user.username)
         await websocket.send(text_data=json.dumps({
             'type': 'gameSession',
             'game_name': game_name,
@@ -38,9 +38,9 @@ async def send_match_jwt_to_all(consumer, players_list, game_name):
         player = player_info['player']
         user = await get_user_by_player(player)
         player_id = player_info['players_id']
-        game_token = await issue_jwt(user, player_id, match.id, game_name)
-        websocket = player_info['websocket']
         player_name = f'player{index + 1}'
+        game_token = await issue_jwt(user, player_name, player_id, match.id, game_name)
+        websocket = player_info['websocket']
         await websocket.send(text_data=json.dumps({
             'type': 'gameSession',
             'game_name': game_name, 
@@ -67,12 +67,13 @@ def get_player_by_user(user):
         return None
 
 @database_sync_to_async
-def issue_jwt(user, players_id, match_id, game_name='pong'):
+def issue_jwt(user, player_name, players_id, match_id, game_name='pong'):
     expire = datetime.utcnow() + timedelta(minutes=1)
     payload = {
         'game_name': game_name,
         'user_id': user.id,
         'username': user.username,
+        'player_name': player_name,
         'players_id': players_id,
         'match_id': match_id,
         'iat': datetime.utcnow(),

--- a/pong-server/game-server/pong/consumers.py
+++ b/pong-server/game-server/pong/consumers.py
@@ -73,8 +73,8 @@ class PongConsumer(AsyncWebsocketConsumer):
 
         if action == 'authenticate':
             jwt = text_data_json.get('jwt')
-            self.player_name = text_data_json.get('player_name')
-            players_id, username, jwt_match_id = await self.auhtnticate_jwt(jwt)
+            players_id, player_name, username, jwt_match_id = await self.auhtnticate_jwt(jwt)
+            self.player_name = player_name
 
             if not players_id or not username or not jwt_match_id:
                 logger.error('Error occured while decoding JWT')
@@ -302,10 +302,11 @@ class PongConsumer(AsyncWebsocketConsumer):
             user_id = validated_token['user_id']
             username = validated_token['username']
             players_id = validated_token['players_id']
+            player_name = validated_token['player_name']
             match_id = validated_token['match_id']
             logger.info(
                 f'authenticate_jwt: user_id={user_id}, username={username}, players_id={players_id}, match_id={match_id}')
-            return players_id, username, match_id
+            return players_id, player_name, username, match_id
         except InvalidToken as e:
             logger.error('Error: invalid token in jwt')
             return None, None

--- a/pong-server/game-server/pong/consumers.py
+++ b/pong-server/game-server/pong/consumers.py
@@ -75,7 +75,7 @@ class PongConsumer(AsyncWebsocketConsumer):
 
         if action == 'authenticate':
             jwt = text_data_json.get('jwt')
-            players_id, player_name, username, jwt_match_id = await self.auhtnticate_jwt(jwt)
+            players_id, player_name, username, jwt_match_id = await self.authenticate_jwt(jwt)
             self.player_name = player_name
 
             if not players_id or not username or not jwt_match_id:

--- a/pong4-server/game-server/pong4/consumers.py
+++ b/pong4-server/game-server/pong4/consumers.py
@@ -73,7 +73,7 @@ class PongConsumer(AsyncWebsocketConsumer):
 
         if action == 'authenticate':
             jwt = text_data_json.get('jwt')
-            players_id, player_name, username, jwt_match_id = await self.auhtnticate_jwt(jwt)
+            players_id, player_name, username, jwt_match_id = await self.authenticate_jwt(jwt)
             self.player_name = player_name
 
             if not players_id or not username or not jwt_match_id:
@@ -294,7 +294,7 @@ class PongConsumer(AsyncWebsocketConsumer):
         self.left_paddle.score = left_paddle_data['score']
 
     @database_sync_to_async
-    def auhtnticate_jwt(self, jwt):
+    def authenticate_jwt(self, jwt):
         try:
             token_backend = TokenBackend(algorithm='HS256', signing_key=settings.SIMPLE_JWT['SIGNING_KEY'])
             validated_token = token_backend.decode(jwt, verify=True)

--- a/pong4-server/game-server/pong4/consumers.py
+++ b/pong4-server/game-server/pong4/consumers.py
@@ -73,8 +73,8 @@ class PongConsumer(AsyncWebsocketConsumer):
 
         if action == 'authenticate':
             jwt = text_data_json.get('jwt')
-            self.player_name = text_data_json.get('player_name')
-            players_id, username, jwt_match_id = await self.auhtnticate_jwt(jwt)
+            players_id, player_name, username, jwt_match_id = await self.auhtnticate_jwt(jwt)
+            self.player_name = player_name
 
             if not players_id or not username or not jwt_match_id:
                 logger.error('Error occured while decoding JWT')
@@ -302,10 +302,11 @@ class PongConsumer(AsyncWebsocketConsumer):
             user_id = validated_token['user_id']
             username = validated_token['username']
             players_id = validated_token['players_id']
+            player_name = validated_token['player_name']
             match_id = validated_token['match_id']
             logger.info(
                 f'authenticate_jwt: user_id={user_id}, username={username}, players_id={players_id}, match_id={match_id}')
-            return players_id, username, match_id
+            return players_id, player_name, username, match_id
         except InvalidToken as e:
             logger.error('Error: invalid token in jwt')
             return None, None


### PR DESCRIPTION
#113 に対応

player_name（player1やplayer2など）はゲームサーバー上でどのプレイヤーであるかを判断する重要なキーなため、悪意を持ったユーザーがクライアントを書き換えるとplayer2であってもplayer1として申告することにより、ゲームの進行を妨げることが可能だった。

今回の変更はbackend側で生成するJWTに含めることでこの種の攻撃を不可能にする。