### PR TITLE
Feature/refresh token friends api

### DIFF
--- a/frontend/static_vol/js/modules/friendList.js
+++ b/frontend/static_vol/js/modules/friendList.js
@@ -10,11 +10,11 @@ const updateFriendsList = async (pageInstance) => {
     const isPageFriend = PageBase.isInstance(pageInstance, 'Friends');
     try {
         const friends = await fetchFriends();
-        const listFriendsWrappr = document.querySelector('.blockFriends_friends');
-        if (friends.length === 0) {
-            listFriendsWrappr.innerHTML = `<p>${labels.friends.msgNoFriends}</p>`
+        const listFriendsWrapper = document.querySelector('.blockFriends_friends');
+        if (!friends || friends.length === 0) {
+            listFriendsWrapper.innerHTML = `<p>${labels.friends.msgNoFriends}</p>`
         } else {
-            listFriendsWrappr.innerHTML = '';
+            listFriendsWrapper.innerHTML = '';
             friends.forEach(friend => {
                 let friendElement = `
                     <section class="unitFriend">
@@ -32,7 +32,7 @@ const updateFriendsList = async (pageInstance) => {
                 friendElement += `</ul>
                     </section>
                 `;
-                listFriendsWrappr.innerHTML += friendElement;
+                listFriendsWrapper.innerHTML += friendElement;
             });
             resetListenFriendList(pageInstance);
         }
@@ -45,9 +45,9 @@ const updateFriendRequestList = async (pageInstance) => {
     console.log('updateFriendRequestList in');
     try {
         const requests = await fetchFriendRequests();
-            const secRequestWrapper = document.querySelector('.blockFriendRequest');
-            const listRequestWrapper = document.querySelector('.blockFriendRequest_friends');
-        if (requests.length === 0) {
+        const secRequestWrapper = document.querySelector('.blockFriendRequest');
+        const listRequestWrapper = document.querySelector('.blockFriendRequest_friends');
+        if (!requests || requests.length === 0) {
             if (!secRequestWrapper.classList.contains('is-noRequest')) {
                 secRequestWrapper.classList.add('is-noRequest');
             }

--- a/frontend/static_vol/js/modules/friendList.js
+++ b/frontend/static_vol/js/modules/friendList.js
@@ -9,7 +9,7 @@ const updateFriendsList = async (pageInstance) => {
     console.log('updateFriendList in');
     const isPageFriend = PageBase.isInstance(pageInstance, 'Friends');
     try {
-        const friends = await fetchFriends();
+        const friends = await fetchFriends(false);
         const listFriendsWrapper = document.querySelector('.blockFriends_friends');
         if (!friends || friends.length === 0) {
             listFriendsWrapper.innerHTML = `<p>${labels.friends.msgNoFriends}</p>`
@@ -44,7 +44,7 @@ const updateFriendsList = async (pageInstance) => {
 const updateFriendRequestList = async (pageInstance) => {
     console.log('updateFriendRequestList in');
     try {
-        const requests = await fetchFriendRequests();
+        const requests = await fetchFriendRequests(false);
         const secRequestWrapper = document.querySelector('.blockFriendRequest');
         const listRequestWrapper = document.querySelector('.blockFriendRequest_friends');
         if (!requests || requests.length === 0) {

--- a/frontend/static_vol/js/modules/friendsApi.js
+++ b/frontend/static_vol/js/modules/friendsApi.js
@@ -1,6 +1,6 @@
 import { getToken, refreshAccessToken } from './token.js';
 
-export const fetchFriends = async () => {
+export const fetchFriends = async (isRefresh) => {
     const accessToken = getToken('accessToken');
     if (accessToken === null) {
         return Promise.resolve(null);
@@ -11,8 +11,16 @@ export const fetchFriends = async () => {
                 'Authorization': `Bearer ${accessToken}`
             }
         });
-        if (!response.ok) {
-            throw new Error('Failed to fetch friends');
+        if (!response.ok) { //response.status=>403
+            if (!isRefresh) {
+                if (!await refreshAccessToken()) {
+                    throw new Error('fail refresh token');
+                }
+                return await fetchFriends(true);
+            } else {
+                throw new Error('refreshed accessToken is invalid.');
+            }
+            throw new Error(`Failed to fetch friends: ${response.status}`);
         }
         const data = await response.json();
         console.log('fetchFriends API response: ', data);
@@ -22,7 +30,7 @@ export const fetchFriends = async () => {
     }
 };
 
-export const fetchFriendRequests = async () => {
+export const fetchFriendRequests = async (isRefresh) => {
     const accessToken = getToken('accessToken');
     if (accessToken === null) {
         return Promise.resolve(null);
@@ -33,8 +41,16 @@ export const fetchFriendRequests = async () => {
                 'Authorization': `Bearer ${accessToken}`
             }
         });
-        if (!response.ok) {
-            throw new Error('Failed to fetch frined requests');
+        if (!response.ok) { //response.status=>403
+            if (!isRefresh) {
+                if (!await refreshAccessToken()) {
+                    throw new Error('fail refresh token');
+                }
+                return await fetchFriendRequests(true);
+            } else {
+                throw new Error('refreshed accessToken is invalid.');
+            }
+            throw new Error(`Failed to fetch friends requests: ${response.status}`);
         }
         const data = await response.json();
         console.log('fetchFriendRequests API response: ', data);


### PR DESCRIPTION
accessTokenが期限切れの際に
friendsリスト、friends request リストが取得できなくなっていた件、
accessTokenが期限切れならrefreshTokenして再度取りに行くようにしました。

`/backend/scandamus/scandamus/settings.py`
SIMPLE_JWTのACCESS_TOKEN_LIFETIME をかなり短く（1分とか）設定して
dashboard表示=>ACCESS_TOKEN_LIFETIME経過後、「View all friends」からfrinedにSPA遷移して
エラー=>refresh=>取得のフローを踏んでいるのを確認するなどいただけるといただけると🙏