### PR TITLE
Handle match request while matching [REOPEN]

### DIFF
--- a/backend/scandamus/game/consumers.py
+++ b/backend/scandamus/game/consumers.py
@@ -8,6 +8,9 @@ from .friends import send_friend_request, send_friend_request_by_username, accep
 from players.auth import handle_auth
 from .friend_match import handle_request_game, handle_accept_game, handle_reject_game, handle_cancel_game
 from .lounge_match import handle_join_lounge_match, handle_exit_lounge_room
+from .match_utils import get_player_by_user
+from channels.db import database_sync_to_async
+from django.db import transaction
 
 logger = logging.getLogger(__name__)
 
@@ -83,5 +86,33 @@ class LoungeSession(AsyncWebsocketConsumer):
         if hasattr(self, 'user') and self.user.username in self.players:
             del self.players[self.user.username]
             logger.info(f'User {self.user.username} disconnected and removed from players list.')
+
+            # remove pending_requests
+            request_to_remove = []
+            for request_id, request in self.pending_requests.items():
+                if request['from_username'] == self.user.username:
+                    request_to_remove.append(request_id)
+
+            for request_id in request_to_remove:
+                request = self.pending_requests.pop(request_id)
+                logger.info(f'Removed pending request {request_id} due to disconnection')
+
+                to_username = request['to_username']
+                if to_username in self.players:
+                    await self.players[to_username].send(text_data=json.dumps({
+                        'type': 'friendMatchRequest',
+                        'action': 'cancelled',                
+                    }))
+                    logger.info(f'Cancelled successfully and informed opponent player')
+                else:
+                    logger.error(f'Cancelled successfully but opponent is not online')
+
+            # reset player status
+            player = await get_player_by_user(self.user)
+            if player and player.status in ['friend_waiting', 'lounge_waiting']:
+                player.status = 'waiting'
+                await database_sync_to_async(player.save)()
+                logger.info(f'{self.user.username} status set to waiting')
+
         else:
             logger.info('Disconnect called but no user found.')

--- a/backend/scandamus/game/friend_match.py
+++ b/backend/scandamus/game/friend_match.py
@@ -7,7 +7,7 @@ from .models import Player
 from .models import Match
 from django.conf import settings
 from django.db import transaction
-from .match_utils import send_friend_match_jwt, authenticate_token, get_player_by_username, get_player_by_user
+from .match_utils import send_friend_match_jwt, authenticate_token, get_player_by_username, get_player_by_user, update_player_status
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,7 @@ async def handle_request_game(consumer, data):
             logger.error(f'Failed to send to consumer: {e}')
         return
     
+    logger.info(f'opponent player: {opponent_name} status {opponent_player.status}')
     if opponent_player.status != 'waiting':
         logger.info(f'Opppnent player: {opponent_name} is not in waiting status')
         try:
@@ -83,6 +84,10 @@ async def handle_request_game(consumer, data):
                 'request_id': request_id,
             }))
             logger.info(f'Sent to opponent {opponent_name}')
+            await update_player_status(player, 'friend_waiting')
+            await update_player_status(opponent_player, 'friend_waiting')
+            logger.info(f'player.status:{user.username} status:{player.status}')
+            logger.info(f'opponent_player:{opponent_name} status:{player.status}')
         except Exception as e:
             logger.error(f'Failed to send message to {opponent_name}: {e}')
     else:
@@ -165,10 +170,15 @@ async def handle_reject_game(consumer, data):
         if consumer.user.username != to_username:
             logger.error(f'Error in handle_reject_game: invalid request for reject ID:{request_id} from {consumer.username}')
             return
+        
+        to_player = await get_player_by_username(to_username)
+        update_player_status(to_player, 'waiting')
 
         from_username = request['from_username']
         if from_username in consumer.players:
             from_socket = consumer.players[from_username]
+            from_player = await get_player_by_username(from_username)
+            update_player_status(from_player, 'waiting')
             await from_socket.send(text_data=json.dumps({
                 'type': 'friendMatchRequest',
                 'action': 'rejected',
@@ -188,11 +198,16 @@ async def handle_cancel_game(consumer, data):
     try:
         request_id = f'{consumer.user.username}_vs_{opponent_name}'
         if not request_id in LoungeSession.pending_requests:
+            logger.error(f'{consumer.user.username} request cancel invalid friend request {request_id}')
             return
         
         request = LoungeSession.pending_requests.pop(request_id)
+        await update_player_status(consumer.player, 'waiting')
+
         to_username = request['to_username']
         if to_username in consumer.players:
+            to_player = await get_player_by_username(to_username)
+            await update_player_status(to_player, 'waiting')
             await consumer.players[to_username].send(text_data=json.dumps({
                 'type': 'friendMatchRequest',
                 'action': 'cancelled',                

--- a/backend/scandamus/game/lounge_match.py
+++ b/backend/scandamus/game/lounge_match.py
@@ -7,7 +7,7 @@ from .models import Player
 from .models import Match
 from django.conf import settings
 from django.db import transaction
-from .match_utils import send_lounge_match_jwt_to_all, authenticate_token, get_player_by_user, get_required_players
+from .match_utils import send_lounge_match_jwt_to_all, authenticate_token, get_player_by_user, get_required_players, update_player_status
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +20,13 @@ async def handle_join_lounge_match(consumer, token, game_name):
     if not user:
         logger.error('Error: Authentication Failed')
         logger.error(f'error={error}')
-        await consumer.send(text_data=json.dumps({
-            'type': 'authenticationFailed',
-            'message': error
-        }))
+        try:
+            await consumer.send(text_data=json.dumps({
+                'type': 'authenticationFailed',
+                'message': error
+            }))
+        except Exception as e:
+            logger.error(f'Failed to send to consumer: {e}')
         return
     
     player = await get_player_by_user(user)
@@ -42,6 +45,8 @@ async def handle_join_lounge_match(consumer, token, game_name):
             'players_id': player.id,
             'websocket': consumer
         }
+
+        await update_player_status(player, 'lounge_waiting')
         logger.info(f"user={user.username} requesting new game match")
         required_players = get_required_players(game_name)
     
@@ -58,6 +63,7 @@ async def handle_exit_lounge_room(consumer, game_name):
         del consumer.gamePlayers[game_name][consumer.user.username]
         logger.info(f'{consumer.user.username}: cancel accepted.')
         await send_available_players(consumer, game_name)
+        await update_player_status(consumer.player, 'waiting')
     else:
         logger.info(f'Handle_exit_lounge_room: no more player in this {game_name} room')
 

--- a/backend/scandamus/game/match_utils.py
+++ b/backend/scandamus/game/match_utils.py
@@ -162,5 +162,6 @@ def update_player_status_and_match(player, match, status):
 
 @database_sync_to_async
 def update_player_status(player, status):
+    logger.info(f'update_player_status {player.user.username}: {status}')
     player.status = status
     player.save()

--- a/backend/scandamus/game/match_utils.py
+++ b/backend/scandamus/game/match_utils.py
@@ -163,3 +163,4 @@ def update_player_status_and_match(player, match, status):
 @database_sync_to_async
 def update_player_status(player, status):
     player.status = status
+    player.save()

--- a/backend/scandamus/game/match_utils.py
+++ b/backend/scandamus/game/match_utils.py
@@ -159,3 +159,7 @@ def update_player_status_and_match(player, match, status):
     player.status = status
     player.current_match = match
     player.save()
+
+@database_sync_to_async
+def update_player_status(player, status):
+    player.status = status


### PR DESCRIPTION
# 多重マッチングの禁止
## #135 の続き
- [x] フレンドマッチ待機中（モーダル表示中）に別のフレンドマッチを受けないようにする
- [x] ラウンジマッチ待機中（モーダル表示中）にフレンドマッチを受けないようにする

## backendのWebSocketが切断した際の処理を追加
- Playerのstatusがマッチング中の際はwaitingにリセット
- 試合中の場合はそのまま。TODO: 将来のPRで再接続時にstatusを確認し、試合中であってまだ終了していないMatchであればゲーム画面へ遷移：意図しない切断時の救済措置
- フレンドマッチリクエストの最中に切断した場合にpending_requestsから当該要素を削除

## #137 を最新mainブランチベースでコミットし直し
migrationの問題を避けるため最新のmainベースとしてリオープンしました
修正内容は同じです

@snara-42  さんご指摘の問題は確認出来ませんでした。問題が起きましたらログなどご提供いただけると大変助かります。