### PR TITLE
reloadしたらLogOut

### DIFF
--- a/backend/scandamus/players/views.py
+++ b/backend/scandamus/players/views.py
@@ -7,7 +7,6 @@ from rest_framework import viewsets, renderers, status, generics
 from .models import Player, FriendRequest
 from django.contrib.auth.models import User
 from .serializers import PlayerSerializer, UserSerializer, FriendRequestSerializer, UsernameSerializer
-from game.serializers import MatchSerializer
 
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
@@ -125,19 +124,11 @@ class UserInfoView(APIView):
     def get(self, request, format=None):
         user = request.user
         player = Player.objects.get(user=user)
-        current_match = player.current_match
-
-        if current_match:
-            match_serializer = MatchSerializer(current_match)
-            current_match_data = match_serializer.data
-        else:
-            current_match_data = None
 
         data = {
             'is_authenticated': user.is_authenticated,
             'username': user.username,
             'avatar': player.avatar.url if player.avatar else '',
-            'current_match': current_match_data,
         }
         return Response(data)
 

--- a/backend/scandamus/players/views.py
+++ b/backend/scandamus/players/views.py
@@ -7,6 +7,7 @@ from rest_framework import viewsets, renderers, status, generics
 from .models import Player, FriendRequest
 from django.contrib.auth.models import User
 from .serializers import PlayerSerializer, UserSerializer, FriendRequestSerializer, UsernameSerializer
+from game.serializers import MatchSerializer
 
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
@@ -124,11 +125,19 @@ class UserInfoView(APIView):
     def get(self, request, format=None):
         user = request.user
         player = Player.objects.get(user=user)
+        current_match = player.current_match
+
+        if current_match:
+            match_serializer = MatchSerializer(current_match)
+            current_match_data = match_serializer.data
+        else:
+            current_match_data = None
 
         data = {
             'is_authenticated': user.is_authenticated,
             'username': user.username,
             'avatar': player.avatar.url if player.avatar else '',
+            'current_match': current_match_data,
         }
         return Response(data)
 

--- a/frontend/static_vol/js/components/Home.js
+++ b/frontend/static_vol/js/components/Home.js
@@ -118,9 +118,6 @@ export default class LogIn extends PageBase {
                 if (data) {
                     switchDisplayAccount()
                         .then(() => {
-                            if (data.current_match) {
-                                window.history.pushState({}, null, `/game/${data.current_match.game_name}/play:${data.current_match.id}`);
-                            }
                             router(true).then(() => {});
                         });
                 }

--- a/frontend/static_vol/js/components/Home.js
+++ b/frontend/static_vol/js/components/Home.js
@@ -102,8 +102,8 @@ export default class LogIn extends PageBase {
                 return response.json();
             })
             .then(data => {
-                localStorage.setItem('accessToken', data.access_token);
-                localStorage.setItem('refreshToken', data.refresh_token);
+                sessionStorage.setItem('accessToken', data.access_token);
+                sessionStorage.setItem('refreshToken', data.refresh_token);
                 webSocketManager.openWebSocket('lounge', pongHandler)
                     .then(() => {
                         //return webSocketManager.sendAccessToken('lounge');

--- a/frontend/static_vol/js/components/Home.js
+++ b/frontend/static_vol/js/components/Home.js
@@ -118,6 +118,9 @@ export default class LogIn extends PageBase {
                 if (data) {
                     switchDisplayAccount()
                         .then(() => {
+                            if (data.current_match) {
+                                window.history.pushState({}, null, `/game/${data.current_match.game_name}/play:${data.current_match.id}`);
+                            }
                             router(true).then(() => {});
                         });
                 }

--- a/frontend/static_vol/js/main.js
+++ b/frontend/static_vol/js/main.js
@@ -33,3 +33,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     // 言語切り替え
     switchLanguage();
 });
+
+//reload
+window.addEventListener('beforeunload', () => {
+    sessionStorage.removeItem('accessToken');
+    sessionStorage.removeItem('refreshToken');
+});

--- a/frontend/static_vol/js/modules/logout.js
+++ b/frontend/static_vol/js/modules/logout.js
@@ -43,8 +43,8 @@ const handleLogout = (ev) => {
         .finally(() => {
             //todo: catchからここに入る場合は強制ログアウト。画面にエラー表示を出すか？
             //token rm
-            localStorage.removeItem('accessToken');
-            localStorage.removeItem('refreshToken');
+            sessionStorage.removeItem('accessToken');
+            sessionStorage.removeItem('refreshToken');
             webSocketManager.closeWebSocket('lounge');
             webSocketManager.closeWebSocket('pong');
             const siteInfo = new SiteInfo();

--- a/frontend/static_vol/js/modules/token.js
+++ b/frontend/static_vol/js/modules/token.js
@@ -1,9 +1,9 @@
 'use strict';
 
-//localstorageにtokenがkey自体ない=>ログアウト状態
+//sessionStorageにtokenがkey自体ない=>ログアウト状態
 //tokenがundefined=>何かがおかしい
 const getToken = (nameToken) => {
-    const token = localStorage.getItem(nameToken);
+    const token = sessionStorage.getItem(nameToken);
     if (token === null) {
         return null;//未ログイン
     }
@@ -31,8 +31,8 @@ const refreshAccessToken = async () => {
         if (response.ok) {
             const refreshData = await response.json();
             console.log(`refreshData: `, refreshData);
-            localStorage.setItem('accessToken', refreshData.access);
-            localStorage.setItem('refreshToken', refreshData.refresh);
+            sessionStorage.setItem('accessToken', refreshData.access);
+            sessionStorage.setItem('refreshToken', refreshData.refresh);
             console.log(`Successfully token refreshed: ${refreshData.access}`);
             return refreshData.access;
         }


### PR DESCRIPTION
リロードしたらログアウトするようにしました。

セッションを跨いでtokenを保持する必要がなくなったので、
tokenの保存先をlocalStorageからsessionStorageに変更しています。

---
リロード後に自動ログインしてしまう場合、
localStorageにtokenが残っていると思われます。
お手数ですが手動で削除お願いします🙏

---
https://github.com/scandamus/ft_transcendence/issues/79
なぜかログインしていることになってしまう不具合については
以前のセッションでlocalStorageに保持されたtokenの扱いが適切ではなかったためと推測されるので、
このPRの変更によって改善されるはずです