### PR TITLE
[friend]recommendedからの友達申請

### DIFF
--- a/backend/scandamus/game/consumers.py
+++ b/backend/scandamus/game/consumers.py
@@ -74,8 +74,6 @@ class LoungeSession(AsyncWebsocketConsumer):
             elif msg_type == 'friendRequest':
                 if action == 'requestByUsername':
                     await send_friend_request_by_username(self, text_data_json['username'])
-                elif action == 'sendRequest':
-                    await send_friend_request(self, text_data_json['user_id'])
                 elif action == 'acceptRequest':
                     await accept_friend_request(self, text_data_json['request_id'])
                 elif action == 'declineRequest':

--- a/backend/scandamus/game/friends.py
+++ b/backend/scandamus/game/friends.py
@@ -45,7 +45,7 @@ def get_player_from_user(user):
 @database_sync_to_async
 def get_user_by_username(username):
     logger.info(f'get_user_by_username: username= {username}')
-    return User.objects.get(username=username)
+    return User.objects.get(username=username, is_superuser=False)
 
 @database_sync_to_async
 def create_friend_request(from_user, to_user):

--- a/backend/scandamus/players/serializers.py
+++ b/backend/scandamus/players/serializers.py
@@ -170,3 +170,18 @@ class MatchLogSerializer(serializers.ModelSerializer):
                 players.append(
                     {'username': player_info['username'], 'avatar': player_info['avatar'], 'score': player_info['score'], 'is_win': player_info['is_win']})
         return players
+
+class RecommendedSerializer(serializers.ModelSerializer):
+    username = serializers.CharField(source='user.username')
+    avatar = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Player
+        fields = ['username', 'avatar']
+
+    def get_username(self, obj):
+        user = self.context['request'].user
+        return user.username
+
+    def get_avatar(self, obj):
+        return obj.avatar.url if obj.avatar else None

--- a/backend/scandamus/players/urls.py
+++ b/backend/scandamus/players/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 # ↓ view.pyの全てのviewをimport
 # from . import views
 # ↓ view.pyから指定したviewをimport（推奨）
-from .views import LoginView, UserInfoView, LogoutView, RegisterView, DeleteUserView, ValidateView, FriendListView, FriendRequestListView, AvatarUploadView, MatchLogView
+from .views import LoginView, UserInfoView, LogoutView, RegisterView, DeleteUserView, ValidateView, FriendListView, FriendRequestListView, AvatarUploadView, MatchLogView, RecommendedView
 
 urlpatterns = [
     path('login/', LoginView.as_view(), name='login'),
@@ -23,4 +23,5 @@ urlpatterns = [
     path('requests/', FriendRequestListView.as_view(), name='friend-request-list'),
     path('avatar/', AvatarUploadView.as_view(), name='avatar_upload'),
     path('matchlog/', MatchLogView.as_view(), name='log-match'),
+    path('recommend/', RecommendedView.as_view(), name='recommend'),
 ]

--- a/backend/scandamus/players/views.py
+++ b/backend/scandamus/players/views.py
@@ -18,6 +18,7 @@ from rest_framework import permissions
 from rest_framework.permissions import IsAuthenticated
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.parsers import MultiPartParser
+import random
 
 # from django.http import JsonResponse
 # from django.views.decorators.csrf import csrf_exempt
@@ -242,7 +243,7 @@ class RecommendedView(APIView):
         current_friends = player.friends.all()
         matches = Match.objects.filter(
             Q(player1=player) | Q(player2=player) | Q(player3=player) | Q(player4=player)
-        )[:20]
+        ).order_by('-id')[:30]
         opponents = set()
         for match in matches:
             if match.player1 != player and match.player1 not in current_friends:
@@ -254,8 +255,8 @@ class RecommendedView(APIView):
             if match.player4 and match.player4 != player and match.player4 not in current_friends:
                 opponents.add(match.player4)
 
-            # 最大10人まで取得
-            if len(opponents) >= 10:
-                break
-        serializer = RecommendedSerializer(opponents, many=True, context={'request': request})
+            if len(opponents) > 3:
+                opponents = list(opponents)
+                random.shuffle(opponents)
+        serializer = RecommendedSerializer(list(opponents)[:3], many=True, context={'request': request})
         return Response(serializer.data)

--- a/backend/scandamus/players/views.py
+++ b/backend/scandamus/players/views.py
@@ -241,13 +241,14 @@ class RecommendedView(APIView):
         except Player.DoesNotExist:
             return Response({'detail': 'Player not found'}, status=404)
         current_friends = player.friends.all()
+        sent_requests = FriendRequest.objects.filter(from_user=player).values_list('to_user', flat=True)
         matches = Match.objects.filter(
             Q(player1=player) | Q(player2=player) | Q(player3=player) | Q(player4=player)
         ).order_by('-id')[:30]
         opponents = {
             opponent for match in matches
             for opponent in [match.player1, match.player2, match.player3, match.player4]
-            if opponent is not None and opponent != player and opponent not in current_friends
+            if opponent is not None and opponent != player and opponent not in current_friends and opponent.id not in sent_requests
         }
         opponents = list(opponents)
         random.shuffle(opponents)

--- a/backend/scandamus/players/views.py
+++ b/backend/scandamus/players/views.py
@@ -244,19 +244,12 @@ class RecommendedView(APIView):
         matches = Match.objects.filter(
             Q(player1=player) | Q(player2=player) | Q(player3=player) | Q(player4=player)
         ).order_by('-id')[:30]
-        opponents = set()
-        for match in matches:
-            if match.player1 != player and match.player1 not in current_friends:
-                opponents.add(match.player1)
-            if match.player2 != player and match.player2 not in current_friends:
-                opponents.add(match.player2)
-            if match.player3 and match.player3 != player and match.player3 not in current_friends:
-                opponents.add(match.player3)
-            if match.player4 and match.player4 != player and match.player4 not in current_friends:
-                opponents.add(match.player4)
-
-            if len(opponents) > 3:
-                opponents = list(opponents)
-                random.shuffle(opponents)
-        serializer = RecommendedSerializer(list(opponents)[:3], many=True, context={'request': request})
+        opponents = {
+            opponent for match in matches
+            for opponent in [match.player1, match.player2, match.player3, match.player4]
+            if opponent is not None and opponent != player and opponent not in current_friends
+        }
+        opponents = list(opponents)
+        random.shuffle(opponents)
+        serializer = RecommendedSerializer(opponents[:5], many=True, context={'request': request})
         return Response(serializer.data)

--- a/frontend/static_vol/css/style.css
+++ b/frontend/static_vol/css/style.css
@@ -875,7 +875,7 @@ input.has-input:invalid {
   justify-content: flex-end;
   align-items: center;
   padding-right: 0.5em;
-  flex: 1 1 calc(100% - 160px);
+  flex: 1 1 calc(100% - 170px);
   min-width: 60%;
 }
 

--- a/frontend/static_vol/css/style.css
+++ b/frontend/static_vol/css/style.css
@@ -788,7 +788,8 @@ input.has-input:invalid {
 
 /* no data */
 .blockFriends_friends p:only-child,
-.blockDashboardLog_listMatch p:only-child {
+.blockDashboardLog_listMatch p:only-child,
+.blockFriendRecommended_friends p:only-child {
   font-size: 1.8rem;
   margin-top: 1em;
   margin-bottom: 1em;

--- a/frontend/static_vol/js/components/Friends.js
+++ b/frontend/static_vol/js/components/Friends.js
@@ -6,10 +6,9 @@ import { initToken } from '../modules/token.js';
 import { pongHandler } from '../modules/websocketHandler.js';
 import { labels } from '../modules/labels.js';
 import { checkSimpleInputValid } from "../modules/form.js";
-import { updateFriendsList, updateFriendRequestList } from '../modules/friendList.js';
+import { updateFriendsList, updateFriendRequestList, updateRecommend } from '../modules/friendList.js';
 import { removeListenMatchRequest, removeListenAcceptFriendRequest, removeListenDeclineFriendRequest, removeListenRemoveFriend, addListenSendFriendRequest }
     from '../modules/friendListener.js';
-import { updateRecommend } from "../modules/gameList.js";
 
 export default class Friends extends PageBase {
     constructor(params) {

--- a/frontend/static_vol/js/components/Friends.js
+++ b/frontend/static_vol/js/components/Friends.js
@@ -65,7 +65,7 @@ export default class Friends extends PageBase {
         try {
             updateFriendsList(this).then(() => {});
             updateFriendRequestList(this).then(() => {});
-            updateRecommend().then(() => {});
+            updateRecommend(this).then(() => {});
             //recommendedのaddListener
             addListenSendFriendRequest(this);
         } catch (error) {

--- a/frontend/static_vol/js/components/Friends.js
+++ b/frontend/static_vol/js/components/Friends.js
@@ -9,6 +9,7 @@ import { checkSimpleInputValid } from "../modules/form.js";
 import { updateFriendsList, updateFriendRequestList } from '../modules/friendList.js';
 import { removeListenMatchRequest, removeListenAcceptFriendRequest, removeListenDeclineFriendRequest, removeListenRemoveFriend, addListenSendFriendRequest }
     from '../modules/friendListener.js';
+import { updateRecommend } from "../modules/gameList.js";
 
 export default class Friends extends PageBase {
     constructor(params) {
@@ -53,35 +54,7 @@ export default class Friends extends PageBase {
                     </section>
                     <section class="blockFriendRecommended">
                         <h3 class="blockFriendRecommended_title unitTitle1">${labels.friends.labelRecommended}</h3>
-                        <div class="blockFriendRecommended_friends listFriends listLineDivide">
-                            <section class="unitFriend">
-                                <header class="unitFriend_header">
-                                    <h4 class="unitFriend_name">${'username'}</h4>
-                                    <p class="unitFriend_thumb"><img src="//ui-avatars.com/api/?name=username&background=3cbbc9&color=ffffff" alt="" width="100" height="100"></p>
-                                </header>
-                                <ul class="unitFriendButton unitListBtn unitListBtn-horizontal">
-                                    <li><button type="button" class="unitFriendButton_matchRequest unitButton btnApply" data-username="playertest1" data-id="dummyId1">${labels.friends.labelApply}</button></li>
-                                </ul>
-                            </section>
-                            <section class="unitFriend">
-                                <header class="unitFriend_header">
-                                    <h4 class="unitFriend_name">${'01234567890123456789012345678901'}</h4>
-                                    <p class="unitFriend_thumb"><img src="//ui-avatars.com/api/?name=username&background=3cbbc9&color=ffffff" alt="" width="100" height="100"></p>
-                                </header>
-                                <ul class="unitFriendButton unitListBtn unitListBtn-horizontal">
-                                    <li><button type="button" class="unitFriendButton_matchRequest unitButton btnApply" data-username="playertest1" data-id="dummyId2">${labels.friends.labelApply}</button></li>
-                                </ul>
-                            </section>
-                            <section class="unitFriend">
-                                <header class="unitFriend_header">
-                                    <h4 class="unitFriend_name">${'012'}</h4>
-                                    <p class="unitFriend_thumb"><img src="//ui-avatars.com/api/?name=username&background=3cbbc9&color=ffffff" alt="" width="100" height="100"></p>
-                                </header>
-                                <ul class="unitFriendButton unitListBtn unitListBtn-horizontal">
-                                    <li><button type="button" class="unitFriendButton_matchRequest unitButton btnApply" data-username="playertest1" data-id="dummyId3">${labels.friends.labelApply}</button></li>
-                                </ul>
-                            </section>
-                        </div>
+                        <div class="blockFriendRecommended_friends listFriends listLineDivide"></div>
                     </section>
                 </div>
             </div>
@@ -92,6 +65,7 @@ export default class Friends extends PageBase {
         try {
             updateFriendsList(this).then(() => {});
             updateFriendRequestList(this).then(() => {});
+            updateRecommend().then(() => {});
             //recommendedのaddListener
             addListenSendFriendRequest(this);
         } catch (error) {

--- a/frontend/static_vol/js/components/PageBase.js
+++ b/frontend/static_vol/js/components/PageBase.js
@@ -74,6 +74,11 @@ export default class PageBase {
         this.listListenInInstance.push({element: el, callback: cb, event: ev});
     }
 
+    addListListenOptOnesInInstance(el, cb, ev) {
+        el.addEventListener(ev, cb, { once: true });
+        this.listListenInInstance.push({element: el, callback: cb, event: ev});
+    }
+
     destroy() {
         window.scrollTo({
             top: 0,

--- a/frontend/static_vol/js/modules/friendList.js
+++ b/frontend/static_vol/js/modules/friendList.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import { fetchFriendRequests, fetchFriends } from "./friendsApi.js";
-import { resetListenFriendList, resetListenFriendRequestList } from "./friendListener.js";
+import { fetchFriendRequests, fetchFriends, fetchRecommend } from "./friendsApi.js";
+import { addListenSendFriendRequest, resetListenFriendList, resetListenFriendRequestList } from "./friendListener.js";
 import { labels } from "./labels.js";
 import PageBase from "../components/PageBase.js";
 
@@ -96,4 +96,35 @@ const updateFriendRequestList = async (pageInstance) => {
     }
 }
 
-export { updateFriendsList, updateFriendRequestList }
+const updateRecommend = async (pageInstance) => {
+    console.log('updateRecommend');
+    try {
+        const RecommendedList = await fetchRecommend(false);
+        const RecommendedWrapper = document.querySelector('.blockFriendRecommended_friends');
+        if (!RecommendedList || RecommendedList.length === 0) {
+            RecommendedWrapper.innerHTML = `<p>${labels.friends.msgNoRecommended}</p>`
+        } else {
+            RecommendedWrapper.innerHTML = '';
+            RecommendedList.forEach(player => {
+                const avatar = player.avatar ? player.avatar : '/images/avatar_default.png';
+                const requestElement = `
+                    <section class="unitFriend">
+                        <header class="unitFriend_header">
+                            <h4 class="unitFriend_name">${player.username}</h4>
+                            <p class="unitFriend_thumb"><img src="${avatar}" alt="" width="100" height="100"></p>
+                        </header>
+                        <p class="unitFriendButton">
+                            <button type="button" class="unitFriendButton_friendRequest unitButton" data-username="${player.username}">${labels.friends.labelRequest}</button>
+                        </p>
+                    </section>
+                `;
+                RecommendedWrapper.innerHTML += requestElement;
+            });
+            addListenSendFriendRequest(pageInstance);
+        }
+    } catch (error) {
+        console.error('Failed to update recommended: ', error);
+    }
+}
+
+export { updateFriendsList, updateFriendRequestList, updateRecommend }

--- a/frontend/static_vol/js/modules/friendListener.js
+++ b/frontend/static_vol/js/modules/friendListener.js
@@ -3,10 +3,16 @@
 import { addListenerToList, removeListenerAndClearList } from './listenerCommon.js';
 import { showModalSendMatchRequest } from "./modal.js";
 import { acceptFriendRequest, declineFriendRequest, removeFriend, sendFriendRequest } from "./friendsRequest.js";
+import { labels } from "./labels.js";
 
 const sendFriendRequestHandler = (ev) => {
     const username = ev.target.dataset.username;
     sendFriendRequest(username);
+    const RecommendedWrapper = ev.target.closest('.blockFriendRecommended_friends');
+    ev.target.closest('.unitFriend').remove();
+    if (RecommendedWrapper.children.length === 0) {
+        RecommendedWrapper.innerHTML = `<p>${labels.friends.msgNoRecommended}</p>`
+    }
 }
 
 const acceptFriendRequestHandler = (ev) => {
@@ -100,12 +106,13 @@ const addListenRemoveFriend = (pageInstance) => {
     });
 }
 
-//RequestFriend(Recommended)は表示中の更新がないのでlistListenInInstance[]で管理
+// RequestFriend(Recommended)は表示中の増加がないのでlistListenInInstance[]で管理。
+// clickで消えるのでonceオプションのaddEventListenerに登録
 const addListenSendFriendRequest = (pageInstance) => {
     const btnRequestFriend = document.querySelectorAll('.unitFriendButton_friendRequest');
     const boundSendFriendRequestHandler = sendFriendRequestHandler.bind(pageInstance);
     btnRequestFriend.forEach((btn) => {
-        pageInstance.addListListenInInstance(btn, boundSendFriendRequestHandler, 'click');
+        pageInstance.addListListenOptOnesInInstance(btn, boundSendFriendRequestHandler, 'click');
         console.log(`[Add listener] send friend request to ${btn.dataset.username}`);
     });
 }

--- a/frontend/static_vol/js/modules/friendListener.js
+++ b/frontend/static_vol/js/modules/friendListener.js
@@ -100,7 +100,7 @@ const addListenRemoveFriend = (pageInstance) => {
     });
 }
 
-//RequestFriendは表示中の更新がないのでlistListenInInstance[]で管理
+//RequestFriend(Recommended)は表示中の更新がないのでlistListenInInstance[]で管理
 const addListenSendFriendRequest = (pageInstance) => {
     const btnRequestFriend = document.querySelectorAll('.unitFriendButton_friendRequest');
     const boundSendFriendRequestHandler = sendFriendRequestHandler.bind(pageInstance);

--- a/frontend/static_vol/js/modules/friendsApi.js
+++ b/frontend/static_vol/js/modules/friendsApi.js
@@ -1,6 +1,6 @@
 import { getToken, refreshAccessToken } from './token.js';
 
-export const fetchFriends = async (isRefresh) => {
+const fetchFriends = async (isRefresh) => {
     const accessToken = getToken('accessToken');
     if (accessToken === null) {
         return Promise.resolve(null);
@@ -30,7 +30,7 @@ export const fetchFriends = async (isRefresh) => {
     }
 };
 
-export const fetchFriendRequests = async (isRefresh) => {
+const fetchFriendRequests = async (isRefresh) => {
     const accessToken = getToken('accessToken');
     if (accessToken === null) {
         return Promise.resolve(null);
@@ -59,3 +59,35 @@ export const fetchFriendRequests = async (isRefresh) => {
         console.error('Error fetching frined requests: ', error);
     }
 }
+
+const fetchRecommend = async (isRefresh) => {
+    const accessToken = getToken('accessToken');
+    if (accessToken === null) {
+        return Promise.resolve(null);
+    }
+    try {
+        const response = await fetch('/api/players/recommend/', {
+            headers: {
+                'Authorization': `Bearer ${accessToken}`
+            }
+        });
+        if (!response.ok) { //response.status=>403
+            if (!isRefresh) {
+                if (!await refreshAccessToken()) {
+                    throw new Error('fail refresh token');
+                }
+                return await fetchRecommend(true);
+            } else {
+                throw new Error('refreshed accessToken is invalid.');
+            }
+            throw new Error(`Failed to fetch recommended player: ${response.status}`);
+        }
+        const data = await response.json();
+        console.log('fetchRecommend API response: ', data);
+        return data;
+    } catch (error) {
+        console.error('Error fetching recommended player: ', error);
+    }
+}
+
+export { fetchFriends, fetchFriendRequests, fetchRecommend };

--- a/frontend/static_vol/js/modules/friendsRequest.js
+++ b/frontend/static_vol/js/modules/friendsRequest.js
@@ -11,7 +11,7 @@ const sendFriendRequest = async (to_username) => {
         await webSocketManager.openWebSocket('lounge', pongHandler);
         webSocketManager.sendWebSocketMessage('lounge', {
             type: 'friendRequest',
-            action: 'sendRequest',
+            action: 'requestByUsername',
             username: to_username
         });
     } catch (error) {

--- a/frontend/static_vol/js/modules/gameApi.js
+++ b/frontend/static_vol/js/modules/gameApi.js
@@ -30,34 +30,4 @@ const fetchMatchLog = async (isRefresh) => {
     }
 }
 
-const fetchRecommend = async (isRefresh) => {
-    const accessToken = getToken('accessToken');
-    if (accessToken === null) {
-        return Promise.resolve(null);
-    }
-    try {
-        const response = await fetch('/api/players/recommend/', {
-            headers: {
-                'Authorization': `Bearer ${accessToken}`
-            }
-        });
-        if (!response.ok) { //response.status=>403
-            if (!isRefresh) {
-                if (!await refreshAccessToken()) {
-                    throw new Error('fail refresh token');
-                }
-                return await fetchRecommend(true);
-            } else {
-                throw new Error('refreshed accessToken is invalid.');
-            }
-            throw new Error(`Failed to fetch recommended player: ${response.status}`);
-        }
-        const data = await response.json();
-        console.log('fetchRecommend API response: ', data);
-        return data;
-    } catch (error) {
-        console.error('Error fetching recommended player: ', error);
-    }
-}
-
-export { fetchMatchLog, fetchRecommend };
+export { fetchMatchLog };

--- a/frontend/static_vol/js/modules/gameApi.js
+++ b/frontend/static_vol/js/modules/gameApi.js
@@ -30,4 +30,34 @@ const fetchMatchLog = async (isRefresh) => {
     }
 }
 
-export { fetchMatchLog };
+const fetchRecommend = async (isRefresh) => {
+    const accessToken = getToken('accessToken');
+    if (accessToken === null) {
+        return Promise.resolve(null);
+    }
+    try {
+        const response = await fetch('/api/players/recommend/', {
+            headers: {
+                'Authorization': `Bearer ${accessToken}`
+            }
+        });
+        if (!response.ok) { //response.status=>403
+            if (!isRefresh) {
+                if (!await refreshAccessToken()) {
+                    throw new Error('fail refresh token');
+                }
+                return await fetchRecommend(true);
+            } else {
+                throw new Error('refreshed accessToken is invalid.');
+            }
+            throw new Error(`Failed to fetch recommended player: ${response.status}`);
+        }
+        const data = await response.json();
+        console.log('fetchRecommend API response: ', data);
+        return data;
+    } catch (error) {
+        console.error('Error fetching recommended player: ', error);
+    }
+}
+
+export { fetchMatchLog, fetchRecommend };

--- a/frontend/static_vol/js/modules/gameList.js
+++ b/frontend/static_vol/js/modules/gameList.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { fetchMatchLog, fetchRecommend } from "./gameApi.js";
+import { fetchMatchLog } from "./gameApi.js";
 import { labels } from "./labels.js";
 import { SiteInfo } from "./SiteInfo.js";
 import { addListenSendFriendRequest } from "./friendListener.js";
@@ -63,35 +63,4 @@ const getMatchLog = async () => {
     }
 }
 
-const updateRecommend = async (pageInstance) => {
-    console.log('updateRecommend');
-    try {
-        const RecommendedList = await fetchRecommend(false);
-        const RecommendedWrapper = document.querySelector('.blockFriendRecommended_friends');
-        if (!RecommendedList || RecommendedList.length === 0) {
-            RecommendedWrapper.innerHTML = `<p>${labels.friends.msgNoRecommended}</p>`
-        } else {
-            RecommendedWrapper.innerHTML = '';
-            RecommendedList.forEach(player => {
-                const avatar = player.avatar ? player.avatar : '/images/avatar_default.png';
-                const requestElement = `
-                    <section class="unitFriend">
-                        <header class="unitFriend_header">
-                            <h4 class="unitFriend_name">${player.username}</h4>
-                            <p class="unitFriend_thumb"><img src="${avatar}" alt="" width="100" height="100"></p>
-                        </header>
-                        <p class="unitFriendButton">
-                            <button type="button" class="unitFriendButton_friendRequest unitButton" data-username="${player.username}">${labels.friends.labelRequest}</button>
-                        </p>
-                    </section>
-                `;
-                RecommendedWrapper.innerHTML += requestElement;
-            });
-            addListenSendFriendRequest(pageInstance);
-        }
-    } catch (error) {
-        console.error('Failed to update recommended: ', error);
-    }
-}
-
-export { getMatchLog, updateRecommend }
+export { getMatchLog }

--- a/frontend/static_vol/js/modules/gameList.js
+++ b/frontend/static_vol/js/modules/gameList.js
@@ -69,7 +69,7 @@ const updateRecommend = async (pageInstance) => {
         const RecommendedList = await fetchRecommend(false);
         const RecommendedWrapper = document.querySelector('.blockFriendRecommended_friends');
         if (!RecommendedList || RecommendedList.length === 0) {
-            console.log('no recommended')
+            RecommendedWrapper.innerHTML = `<p>${labels.friends.msgNoRecommended}</p>`
         } else {
             RecommendedWrapper.innerHTML = '';
             RecommendedList.forEach(player => {

--- a/frontend/static_vol/js/modules/gameList.js
+++ b/frontend/static_vol/js/modules/gameList.js
@@ -80,9 +80,9 @@ const updateRecommend = async (pageInstance) => {
                             <h4 class="unitFriend_name">${player.username}</h4>
                             <p class="unitFriend_thumb"><img src="${avatar}" alt="" width="100" height="100"></p>
                         </header>
-                        <ul class="unitFriendButton unitListBtn unitListBtn-horizontal">
-                            <li><button type="button" class="unitFriendButton_friendRequest unitButton" data-username="${player.username}">${labels.friends.labelRequest}</button></li>
-                        </ul>
+                        <p class="unitFriendButton">
+                            <button type="button" class="unitFriendButton_friendRequest unitButton" data-username="${player.username}">${labels.friends.labelRequest}</button>
+                        </p>
                     </section>
                 `;
                 RecommendedWrapper.innerHTML += requestElement;

--- a/frontend/static_vol/js/modules/gameList.js
+++ b/frontend/static_vol/js/modules/gameList.js
@@ -3,7 +3,7 @@
 import { fetchMatchLog, fetchRecommend } from "./gameApi.js";
 import { labels } from "./labels.js";
 import { SiteInfo } from "./SiteInfo.js";
-//import { resetListenFriendRequestList } from "./friendListener.js";
+import { addListenSendFriendRequest } from "./friendListener.js";
 
 const getMatchLog = async () => {
     console.log('getMatchLog');
@@ -87,7 +87,7 @@ const updateRecommend = async (pageInstance) => {
                 `;
                 RecommendedWrapper.innerHTML += requestElement;
             });
-            //resetListenFriendRequestList(pageInstance);
+            addListenSendFriendRequest(pageInstance);
         }
     } catch (error) {
         console.error('Failed to update recommended: ', error);

--- a/frontend/static_vol/js/modules/gameList.js
+++ b/frontend/static_vol/js/modules/gameList.js
@@ -1,8 +1,9 @@
 'use strict';
 
-import { fetchMatchLog } from "./gameApi.js";
+import { fetchMatchLog, fetchRecommend } from "./gameApi.js";
 import { labels } from "./labels.js";
 import { SiteInfo } from "./SiteInfo.js";
+//import { resetListenFriendRequestList } from "./friendListener.js";
 
 const getMatchLog = async () => {
     console.log('getMatchLog');
@@ -62,4 +63,35 @@ const getMatchLog = async () => {
     }
 }
 
-export { getMatchLog }
+const updateRecommend = async (pageInstance) => {
+    console.log('updateRecommend');
+    try {
+        const RecommendedList = await fetchRecommend(false);
+        const RecommendedWrapper = document.querySelector('.blockFriendRecommended_friends');
+        if (!RecommendedList || RecommendedList.length === 0) {
+            console.log('no recommended')
+        } else {
+            RecommendedWrapper.innerHTML = '';
+            RecommendedList.forEach(player => {
+                const avatar = player.avatar ? player.avatar : '/images/avatar_default.png';
+                const requestElement = `
+                    <section class="unitFriend">
+                        <header class="unitFriend_header">
+                            <h4 class="unitFriend_name">${player.username}</h4>
+                            <p class="unitFriend_thumb"><img src="${avatar}" alt="" width="100" height="100"></p>
+                        </header>
+                        <ul class="unitFriendButton unitListBtn unitListBtn-horizontal">
+                            <li><button type="button" class="unitFriendButton_friendRequest unitButton" data-username="${player.username}">${labels.friends.labelRequest}</button></li>
+                        </ul>
+                    </section>
+                `;
+                RecommendedWrapper.innerHTML += requestElement;
+            });
+            //resetListenFriendRequestList(pageInstance);
+        }
+    } catch (error) {
+        console.error('Failed to update recommended: ', error);
+    }
+}
+
+export { getMatchLog, updateRecommend }

--- a/frontend/static_vol/js/modules/labels_ar.js
+++ b/frontend/static_vol/js/modules/labels_ar.js
@@ -58,6 +58,7 @@ export const labels_ar = {
         labelListFriends: ' يؤُلاءِ العربية',
         labelReceivedRequest: ' يؤُلاءِ العربية',
         labelRecommended: ' يؤُلاءِ العربية',
+        msgNoRecommended: '',
     },
     lounge: {
         title: 'Lounge',

--- a/frontend/static_vol/js/modules/labels_ar.js
+++ b/frontend/static_vol/js/modules/labels_ar.js
@@ -52,6 +52,7 @@ export const labels_ar = {
         labelApply: ' يؤُلاءِ العربية',
         labelSearch: ' يؤُلاءِ العربية',
         labelSendRequest: ' يؤُلاءِ العربية',
+        labelRequest: '',
         msgNoUsername: ' يؤُلاءِ العربية',
         msgNoFriends: ' يؤُلاءِ العربية',
         labelListFriends: ' يؤُلاءِ العربية',

--- a/frontend/static_vol/js/modules/labels_en.js
+++ b/frontend/static_vol/js/modules/labels_en.js
@@ -52,6 +52,7 @@ export const labels_en = {
         labelApply: 'start a match',
         labelSearch: 'send friend request',
         labelSendRequest: 'send',
+        labelRequest: 'friend request',
         msgNoUsername: 'Enter a username to send friend request',
         msgNoFriends: 'no friends yet',
         labelListFriends: 'friends',

--- a/frontend/static_vol/js/modules/labels_en.js
+++ b/frontend/static_vol/js/modules/labels_en.js
@@ -58,6 +58,7 @@ export const labels_en = {
         labelListFriends: 'friends',
         labelReceivedRequest: 'friend requests',
         labelRecommended: 'recommended',
+        msgNoRecommended: 'no recommended player',
     },
     lounge: {
         title: 'Lounge',

--- a/frontend/static_vol/js/modules/labels_fr.js
+++ b/frontend/static_vol/js/modules/labels_fr.js
@@ -52,6 +52,7 @@ export const labels_fr = {
         labelApply: '',
         labelSearch: '',
         labelSendRequest: '',
+        labelRequest: '',
         msgNoUsername: '',
         msgNoFriends: '',
         labelListFriends: '',

--- a/frontend/static_vol/js/modules/labels_fr.js
+++ b/frontend/static_vol/js/modules/labels_fr.js
@@ -58,6 +58,7 @@ export const labels_fr = {
         labelListFriends: '',
         labelReceivedRequest: '',
         labelRecommended: '',
+        msgNoRecommended: '',
     },
     lounge: {
         title: '',

--- a/frontend/static_vol/js/modules/labels_he.js
+++ b/frontend/static_vol/js/modules/labels_he.js
@@ -52,6 +52,7 @@ export const labels_he = {
         labelApply: 'הזה עברית ',
         labelSearch: 'הזה עברית ',
         labelSendRequest: 'הזה עברית ',
+        labelRequest: '',
         msgNoUsername: 'הזה עברית ',
         msgNoFriends: 'הזה עברית ',
         labelListFriends: 'הזה עברית ',

--- a/frontend/static_vol/js/modules/labels_he.js
+++ b/frontend/static_vol/js/modules/labels_he.js
@@ -58,6 +58,7 @@ export const labels_he = {
         labelListFriends: 'הזה עברית ',
         labelReceivedRequest: 'הזה עברית ',
         labelRecommended: 'הזה עברית ',
+        msgNoRecommended: '',
     },
     lounge: {
         title: 'Lounge',

--- a/frontend/static_vol/js/modules/labels_ja.js
+++ b/frontend/static_vol/js/modules/labels_ja.js
@@ -58,6 +58,7 @@ export const labels_ja = {
         labelListFriends: '友達一覧',
         labelReceivedRequest: '受け取った友達申請',
         labelRecommended: 'あなたへのおすすめ',
+        msgNoRecommended: 'おすすめユーザーはいません',
     },
     lounge: {
         title: 'Lounge',

--- a/frontend/static_vol/js/modules/labels_ja.js
+++ b/frontend/static_vol/js/modules/labels_ja.js
@@ -52,6 +52,7 @@ export const labels_ja = {
         labelApply: '対戦する',
         labelSearch: '友達申請を送る',
         labelSendRequest: '送信',
+        labelRequest: '友達申請',
         msgNoUsername: '友達申請を送るユーザー名を入力してください',
         msgNoFriends: '友達はまだいません',
         labelListFriends: '友達一覧',

--- a/frontend/static_vol/js/modules/labels_la.js
+++ b/frontend/static_vol/js/modules/labels_la.js
@@ -52,6 +52,7 @@ export const labels_la = {
         labelApply: '',
         labelSearch: '',
         labelSendRequest: '',
+        labelRequest: '',
         msgNoUsername: '',
         msgNoFriends: '',
         labelListFriends: '',

--- a/frontend/static_vol/js/modules/labels_la.js
+++ b/frontend/static_vol/js/modules/labels_la.js
@@ -58,6 +58,7 @@ export const labels_la = {
         labelListFriends: '',
         labelReceivedRequest: '',
         labelRecommended: '',
+        msgNoRecommended: '',
     },
     lounge: {
         title: '',


### PR DESCRIPTION
(#164 からの仕切り直しです)
`/friends` ページ、 recommendedリストが表示されるようにしました。
![rcm](https://github.com/scandamus/ft_transcendence/assets/24986912/911f4aa0-b6b1-472a-ac5c-623daa73ab2f)

- 対象者は最近のmatch30件で対戦したplayer
  (※古すぎるMatch結果から勧められても覚えていないでしょうし、新しい方から件数で対象者を絞ることにしました)
- 上記から、friend, friendリクエスト送信済みのユーザーを除外した上で5人、ランダムに表示
- 対象者のいない場合、`no recommended player`メッセージ表記
- friend requestを送信するとリストから消えます。5人とも消えると`no recommended player`メッセージ表記
- 5人とも消えたら再取得してリスト更新することも考えましたが、対象者全てにFriend申請し尽くすことを続けていくと
  常に対象者が枯渇しそうですし、アクセスごとに5人ずつ小出しにしていくことにしました
