### PR TITLE
fix: Feature/multi language

### DIFF
--- a/frontend/static_vol/js/modules/labels.js
+++ b/frontend/static_vol/js/modules/labels.js
@@ -25,6 +25,6 @@ export const getCurrentLanguageLabels = (lang) => {
 export const labels = {};
 
 export const switchLabels = (lang) => {
-    console.log('!switchLabels!', labels.langCode, '=>', languageLabels[lang].langCode, languageLabels);
+    console.log('!switchLabels!', labels, '=>', getCurrentLanguageLabels(lang));
     Object.assign(labels, getCurrentLanguageLabels(lang));
 };


### PR DESCRIPTION
#162  で localstorage に有効な 'configLang' が存在しないときに `undefined.langCode` を参照していた問題を解消しました。
thanks to @monksoffunk 