### PR TITLE
[update]masterを再決定する処理はmasterがdisconnectされたのがmasterのときのみ

### DIFF
--- a/pong-server/game-server/pong/consumers.py
+++ b/pong-server/game-server/pong/consumers.py
@@ -64,18 +64,18 @@ class PongConsumer(AsyncWebsocketConsumer):
                 logger.info(f'del: {self.players_ids}[{self.match_id}]')
                 del self.players_ids[self.match_id]
             else:
-                new_next_master = sorted(self.players_ids[self.match_id])[0]
-                await self.channel_layer.group_send(self.room_group_name, {
-                    'type': 'start_game',
-                    'master_id': new_next_master,
-                    'state': 'ongoing',
-                })
+                if self.scheduled_task is not None:
+                    self.scheduled_task.cancel()
+                    self.scheduled_task = None
+                    new_next_master = sorted(self.players_ids[self.match_id])[0]
+                    await self.channel_layer.group_send(self.room_group_name, {
+                        'type': 'start_game',
+                        'master_id': new_next_master,
+                        'state': 'ongoing',
+                    })
         await self.channel_layer.group_discard(
             self.room_group_name, self.channel_name
         )
-        if self.scheduled_task is not None:
-            self.scheduled_task.cancel()
-            self.scheduled_task = None
 
     async def receive(self, text_data=None, bytes_data=None):
         text_data_json = json.loads(text_data)

--- a/pong4-server/game-server/pong4/consumers.py
+++ b/pong4-server/game-server/pong4/consumers.py
@@ -72,18 +72,18 @@ class PongConsumer(AsyncWebsocketConsumer):
                 logger.info(f'del: {self.players_ids}[{self.match_id}]')
                 del self.players_ids[self.match_id]
             else:
-                new_next_master = sorted(self.players_ids[self.match_id])[0]
-                await self.channel_layer.group_send(self.room_group_name, {
-                    'type': 'start_game',
-                    'master_id': new_next_master,
-                    'state': 'ongoing',
-                })
+                if self.scheduled_task is not None:
+                    self.scheduled_task.cancel()
+                    self.scheduled_task = None
+                    new_next_master = sorted(self.players_ids[self.match_id])[0]
+                    await self.channel_layer.group_send(self.room_group_name, {
+                        'type': 'start_game',
+                        'master_id': new_next_master,
+                        'state': 'ongoing',
+                    })
         await self.channel_layer.group_discard(
             self.room_group_name, self.channel_name
         )
-        if self.scheduled_task is not None:
-            self.scheduled_task.cancel()
-            self.scheduled_task = None
 
     async def receive(self, text_data=None, bytes_data=None):
         text_data_json = json.loads(text_data)


### PR DESCRIPTION
## 直した機能
- master以外がdisconnectしたときにもcreate_taskしてしまっていたので、内部的なところははわかりません(考えていない)が2倍処理が行われてしまっていました
- 実装的には、scheduled_taskがNoneではないプレーヤーがdisconnectされたときのみcreate_taskをもう一度行います
- master以外のプレーヤーを切断してみてスピードがかわっていないかテストしていただけると