### PR TITLE
[fix]avatar save timing

### DIFF
--- a/backend/scandamus/players/models.py
+++ b/backend/scandamus/players/models.py
@@ -109,22 +109,6 @@ class Player(models.Model):
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
 
-        if self.avatar:
-            self._resize_avatar()
-
-    def _resize_avatar(self):
-        avatar_path = self.avatar.path
-        with Image.open(avatar_path) as img:
-            width, height = img.size
-            min_dim = min(width, height)
-            left = (width - min_dim) / 2
-            top = (height - min_dim) / 2
-            right = (width + min_dim) / 2
-            bottom = (height + min_dim) / 2
-            img = img.crop((left, top, right, bottom))
-            img = img.resize((200, 200), Image.Resampling.LANCZOS)
-            img.save(avatar_path)
-
     def __str__(self):
         return f"{self.user.username} - level:{self.level} / win: {self.win_count} / lang: {self.lang}"
 

--- a/backend/scandamus/players/views.py
+++ b/backend/scandamus/players/views.py
@@ -19,6 +19,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.parsers import MultiPartParser, JSONParser
 import random
+from PIL import Image
+from django.core.files.base import ContentFile
+import io
 
 # from django.http import JsonResponse
 # from django.views.decorators.csrf import csrf_exempt
@@ -228,11 +231,32 @@ class AvatarUploadView(APIView):
         avatar_file = request.FILES.get('avatar')
 
         if avatar_file:
-            player.avatar = avatar_file
-            player.save()
+            resized_avatar = self._resize_avatar(avatar_file)
+            player.avatar.save(avatar_file.name, resized_avatar)
             return Response({"newAvatar": player.avatar.url})
         else:
             return Response({"error": "No avatar file provided"}, status=status.HTTP_400_BAD_REQUEST)
+
+    def _resize_avatar(self, avatar_file):
+        ext = avatar_file.name.split('.')[-1].lower()
+        with Image.open(avatar_file) as img:
+            width, height = img.size
+            min_dim = min(width, height)
+            left = (width - min_dim) / 2
+            top = (height - min_dim) / 2
+            right = (width + min_dim) / 2
+            bottom = (height + min_dim) / 2
+            img = img.crop((left, top, right, bottom))
+            img = img.resize((200, 200), Image.Resampling.LANCZOS)
+
+            img_io = io.BytesIO()
+            if ext in ['jpg', 'jpeg']:
+                img.save(img_io, format='JPEG')
+            elif ext == 'png':
+                img.save(img_io, format='PNG')
+            img_io.seek(0)
+
+            return ContentFile(img_io.read(), avatar_file.name)
 
 class LangUpdateView(APIView):
     authentication_classes = [JWTAuthentication]


### PR DESCRIPTION
すみません！
avatrtのリサイズがPlayer更新時に実行されていました。
Avatar uploadのタイミングで実行されるように修正しました。

なぜか発生するavatar差分、このせいでした。陳謝🙇
https://github.com/scandamus/ft_transcendence/issues/213 こちらのアバターの不整合は別の原因のため改善しておらずです。