### PR TITLE
friendRequestがダブる場合のハンドリング

### DIFF
--- a/frontend/static_vol/js/modules/labels_ar.js
+++ b/frontend/static_vol/js/modules/labels_ar.js
@@ -133,6 +133,8 @@ export const labels_ar = {
         acceptRequestSuccess: 'أنت الآن صديق ل $name ',
         declineRequestSuccess: 'م حذف طلب صداقة ل $name ',
         removeSuccess: 'لقد قمت بإلغاء صداقة $name ',
+        mutualReq: '$name',
+        alreadyReq: '$name',
         received: 'لقد تلقيت طلب صداقة من $name ',
         accepted: 'أنت الآن صديق ل $name ',
         removed: 'لم تعد صديقاً ل $name ',

--- a/frontend/static_vol/js/modules/labels_en.js
+++ b/frontend/static_vol/js/modules/labels_en.js
@@ -133,6 +133,8 @@ export const labels_en = {
         acceptRequestSuccess: '$name is now your friend',
         declineRequestSuccess: 'friend request from $name has been deleted',
         removeSuccess: '$name is no longer your friend',
+        mutualReq: '$name has already sent you a friend request',
+        alreadyReq: 'You have already sent a friend request to $name',
         received: '$name has sent you a friend request',
         accepted: '$name has accepted your friend request',
         removed: '$name is no longer your friend',

--- a/frontend/static_vol/js/modules/labels_fr.js
+++ b/frontend/static_vol/js/modules/labels_fr.js
@@ -133,6 +133,8 @@ export const labels_fr = {
         acceptRequestSuccess: 'Vous êtes maintenant ami avec $name ',
         declineRequestSuccess: 'La demande d’amitié de $name a été annulé',
         removeSuccess: 'Vous avez supprimé l’amitié de $name',
+        mutualReq: '$name',
+        alreadyReq: '$name',
         received: 'Vous avez reçu une demande d’amitié de la part de $name ',
         accepted: '$name a accepté votre demande d’amitié',
         removed: 'Vous n’êtes plus ami avec $name',

--- a/frontend/static_vol/js/modules/labels_he.js
+++ b/frontend/static_vol/js/modules/labels_he.js
@@ -133,6 +133,8 @@ export const labels_he = {
         acceptRequestSuccess: 'אתם עכשיו חברים עם $name',
         declineRequestSuccess: 'מחקת את בקשת החברות של $name',
         removeSuccess: 'מחקת את החבר $name',
+        mutualReq: '$name',
+        alreadyReq: '$name',
         received: '$name שלח לך בקשת חברות',
         accepted: '$name קיבל את בקשת החברות שלך',
         removed: 'אתם כבר לא חברים עם $name',

--- a/frontend/static_vol/js/modules/labels_ja.js
+++ b/frontend/static_vol/js/modules/labels_ja.js
@@ -133,6 +133,8 @@ export const labels_ja = {
         acceptRequestSuccess: '$name さんと友達になりました',
         declineRequestSuccess: '$name さんの友達申請を削除しました',
         removeSuccess: '$name さんとの友達を解除しました',
+        mutualReq: '$name さんからはすでに友達申請を受け取っています',
+        alreadyReq: '$name さんへの友達申請は送信済みです',
         received: '$name さんから友達申請が来ました',
         accepted: '$name さんが友達申請を承認しました',
         removed: '$name さんと友達じゃなくなりました',

--- a/frontend/static_vol/js/modules/labels_la.js
+++ b/frontend/static_vol/js/modules/labels_la.js
@@ -133,6 +133,8 @@ export const labels_la = {
         acceptRequestSuccess: '$name et tu iam amici sunt',
         declineRequestSuccess: 'petitio de $name deleta est',
         removeSuccess: 'iam $name non amicus tibi',
+        mutualReq: '$name',
+        alreadyReq: '$name',
         received: '$name vult tibi amici esse',
         accepted: '$name accepit amici esse',
         removed: '$name non vult amici esse',

--- a/frontend/static_vol/js/modules/websocketHandler.js
+++ b/frontend/static_vol/js/modules/websocketHandler.js
@@ -119,6 +119,10 @@ const handleFriendRequestAck = (data) => {
             addNotice(labels.friendRequest['sendFriendReqSelf'].replace('$name', data.username), true);
         } else if (data.error === 'invalidDeclineFriendReq') {
             addNotice(labels.friendRequest['invalidDeclineFriendReq'].replace('$name', data.username), true);
+        } else if (data.error === 'mutualReq') {
+            addNotice(labels.friendRequest['mutualReq'].replace('$name', data.username), false);
+        } else if (data.error === 'alreadyReq') {
+            addNotice(labels.friendRequest['alreadyReq'].replace('$name', data.username), false);
         } else {
             console.error(`Error: ${data.message}`);
         }


### PR DESCRIPTION
https://github.com/scandamus/ft_transcendence/issues/191 
>お互いに送りあった状態でフレンドリクエストが表示されている＆＆他方がAccept＆＆自身がさらにAcceptすると
>Error: Invalid request idになる

この挙動について、フレンドリクエストの送信時点でリクエストを作成しないようにしました
（バー通知で理由を表示）

- フレンドリクエストを受け取り済みの相手に、逆にリクエストを送ろうとした
- フレンドリクエスト送信済みの相手に重ねてリクエストを送ろうとした
