### PR TITLE
Feature/update game screen

### DIFF
--- a/frontend/static_vol/js/components/GamePlay.js
+++ b/frontend/static_vol/js/components/GamePlay.js
@@ -129,7 +129,7 @@ export default class GamePlay extends PageBase {
             await this.loadSounds();
 
             function drawBackground() {
-                ctx.fillStyle = 'black';
+                ctx.fillStyle = '#00000066';
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
             }
 

--- a/frontend/static_vol/js/components/GamePlay.js
+++ b/frontend/static_vol/js/components/GamePlay.js
@@ -145,10 +145,16 @@ export default class GamePlay extends PageBase {
             }
 
             function drawScore(left_paddle, right_paddle) {
-                ctx.font = '48px "Courier New"';
+                ctx.font = '48px "Chakra Petch"';
                 ctx.textAlign = "center";
                 ctx.fillStyle = '#808080FF';
-                ctx.fillText(`${left_paddle.score}   ${right_paddle.score}`, canvas.width / 2, 50);
+
+                const centerX = canvas.width / 2;
+                const scoreOffset = 54;
+                const posY = 60;
+
+                ctx.fillText(left_paddle.score, centerX - scoreOffset, posY);
+                ctx.fillText(right_paddle.score, centerX + scoreOffset, posY);
             }
 
             function drawBall(obj) {

--- a/frontend/static_vol/js/components/GamePlayQuad.js
+++ b/frontend/static_vol/js/components/GamePlayQuad.js
@@ -140,7 +140,7 @@ export default class GamePlayQuad extends PageBase {
             await this.loadSounds();
 
             function drawBackground() {
-                ctx.fillStyle = 'black';
+                ctx.fillStyle = '#00000066';
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
             }
 
@@ -148,7 +148,7 @@ export default class GamePlayQuad extends PageBase {
                 ctx.lineWidth = line_width;
                 ctx.lineJoin = 'miter';
                 ctx.lineCap = 'butt'
-                ctx.strokeStyle = 'red';
+                ctx.strokeStyle = '#4C4C4C';
                 const offset = line_width / 2;
 
                 // 左上


### PR DESCRIPTION
ゲーム画面、調整しました。
- 背景色の透過
- quadの四隅の色をグレーに変更
パドルや壁の色から不透明のグレーには跳ね返す特性がありそうなので、パドルより少し濃いグレーにしました
- score表示を本文と同じフォントにしてみたのですがどうでしょうか

![dual](https://github.com/user-attachments/assets/159cc5b0-4b9a-495a-b5dc-eff7ac28f019)
![quad](https://github.com/user-attachments/assets/780fdb39-529c-4dbe-9885-8b38de264ec3)
