### PR TITLE
[fix]トーナメントエントリー入力中のフレンドマッチ申請をreject

### DIFF
--- a/frontend/static_vol/js/modules/modal.js
+++ b/frontend/static_vol/js/modules/modal.js
@@ -303,6 +303,11 @@ const showModalReceiveMatchRequest = (data) => {
         labelAccept: labels.modal.labelAccept,
         labelReject: labels.modal.labelReject,
     }
+    const elModal = document.querySelector('.blockModal');
+    if (elModal) {
+        reject_game(data.request_id, data.from).then(() => {});
+        return;
+    }
     const elHtml = getModalHtml('receiveMatchRequest', args);
     showModal(elHtml);
 }


### PR DESCRIPTION
トーナメントへのentry入力中にフレンドマッチを受け取ると、割り込みで受信できてしまっていました。

プレイヤーが意図して行なっているタスクを優先してトーナメントエントリー中は割り込ませず、
rejectを送信元に送ってキャンセルさせるようにしました

https://github.com/scandamus/ft_transcendence/issues/69