### PR TITLE
Exit match for tournament

### DIFF
--- a/backend/scandamus/game/tasks.py
+++ b/backend/scandamus/game/tasks.py
@@ -62,13 +62,10 @@ def check_tournament_start_times():
     # 5分前に準備の通知
     notify_players.delay(tournament_name, entried_players_id_list, 'tournament_prepare', True)
 
-    # 2分前になると控室集合の通知
-    # notify_players.apply_async((tournament_name, entried_players_id_list, 'tournament_room', True), countdown=(tournament.start - now - timedelta(minutes=2)).total_seconds())
-    notify_players.apply_async((tournament_name, entried_players_id_list, 'tournament_room', True), countdown=60 * 3)
+    # 30秒前になると控室集合の通知
+    notify_players.apply_async((tournament_name, entried_players_id_list, 'tournament_room', True), countdown=60 * 4 + 30)
         
-    # 開始時刻の通知
-    # notify_players.apply_async((tournament_name, entried_players_id_list, 'tournament_match', True), countdown=(tournament.start - now).total_seconds())
-    # create_initial_round.apply_async((tournament.id, entried_players_id_list), countdown=(tournament.start - now).total_seconds())
+    # マッチング＆トーナメント開始
     create_initial_round.apply_async((tournament.id, entried_players_id_list), countdown=60 * 5)
 
 @shared_task

--- a/frontend/static_vol/js/modules/tournament.js
+++ b/frontend/static_vol/js/modules/tournament.js
@@ -4,6 +4,9 @@ import { webSocketManager } from './websocket.js';
 import { pongHandler } from './websocketHandler.js';
 import { initToken } from './token.js';
 import { addNotice } from './notice.js';
+import GamePlay from '../components/GamePlay.js';
+import { handleExitGame } from './modal.js';
+import PageBase from '../components/PageBase.js';
 
 const createTournament = async(tournamentTitle, startTime) => {
     console.log(`createTournament ${tournamentTitle} - ${startTime}`);
@@ -64,6 +67,10 @@ const cancelEntryTournament = async(tournamentId, tournamentName) => {
 
 const enterTournamentRoomRequest = async(tournamentName) => {
     console.log(`enterTournamentRoom ${tournamentName}`);
+    if (GamePlay.instance) {
+        handleExitGame(PageBase.instance);
+        addNotice('トーナメントの開始時刻が近づいているためマッチを棄権しました', true);
+    }
     try {
         const accessToken = await initToken();
         await webSocketManager.openWebSocket('lounge', pongHandler);


### PR DESCRIPTION
# マッチ中のトーナメント控室移動
#272 
- トーナメント控室移動を開始30秒前に変更
- その時点でエントリーしているプレイヤーがマッチ中の場合は強制的にExit（handleExitGameを呼ぶ）

現状のhandleExitGameの実装により、単純にそのゲームを破棄して控室に移動するだけで、マッチ自体は継続（相手の1人プレーになる）。別のPRで-1となることを期待しています。