### PR TITLE
Update tournament create starttime handling

### DIFF
--- a/frontend/static_vol/js/components/Tournament.js
+++ b/frontend/static_vol/js/components/Tournament.js
@@ -93,6 +93,7 @@ export default class Tournament extends PageBase {
 
     updateLists() {
         try {
+            this.start_dates = [];
             updateUpcomingTournamentList(this).then((start_dates) => {
                 if (start_dates) {
                     this.start_dates = start_dates;
@@ -187,11 +188,10 @@ export default class Tournament extends PageBase {
             now.setMinutes(now.getMinutes() + CREATE_TOURNAMENT_TIMELIMIT_MIN);
             const minUTC = new Date(now.toISOString());
             const startUTC = new Date(startTime.toISOString());
+
+            elInput.setCustomValidity( '');
             if (startUTC < minUTC) {
                 elInput.setCustomValidity( 'startTimeInvalid');
-            } else {
-                elInput.setCustomValidity( '');
-            }
 
             if (elInput.validity.valid) {
                 let isIntervalInvalid = false;


### PR DESCRIPTION
# トーナメント作成のスタート時間設定の調整

upcomingなトーナメントが読み込まれるとstart_datesが設定されるが、トーナメントが実行されても値が保持されるために以降の設定時にも不本意なバリデーションがかかってしまう問題を解消。
併せてCustomValidityを毎回クリアするように変更。