### PR TITLE
ゲーム終了直後にキー操作を送ろうとしてエラーが発生する

### DIFF
--- a/frontend/static_vol/js/components/GamePlay.js
+++ b/frontend/static_vol/js/components/GamePlay.js
@@ -207,8 +207,6 @@ export default class GamePlay extends PageBase {
                         action: 'end_game',
                         match_id: gameMatchId,
                     }));
-                    webSocketManager.closeWebSocket(this.containerId);
-                    this.containerId = '';
                     const tournamentId = sessionStorage.getItem('tournament_id');
                     if (tournamentId) {
                         sessionStorage.setItem('tournament_status', 'waiting_round');
@@ -218,6 +216,8 @@ export default class GamePlay extends PageBase {
                     }
                     setTimeout(() => {
                         this.playSound(data.sound_type);
+                        webSocketManager.closeWebSocket(this.containerId);
+                        this.containerId = '';
                         router(true);
                     }, 1500);
                 } else {

--- a/frontend/static_vol/js/components/GamePlayQuad.js
+++ b/frontend/static_vol/js/components/GamePlayQuad.js
@@ -261,11 +261,11 @@ export default class GamePlayQuad extends PageBase {
                 if (!data.game_status) {
                     console.log('Game Over');
                     // showWinner([data.right_paddle, data.left_paddle, data.upper_paddle, data.lower_paddle]);
-                    webSocketManager.closeWebSocket(this.containerId);
-                    this.containerId = '';
                     window.history.pushState({}, null, "/dashboard");
                     setTimeout(() => {
                         this.playSound(data.sound_type);
+                        webSocketManager.closeWebSocket(this.containerId);
+                        this.containerId = '';
                         router(true);
                     }, 1500);
                 } else {


### PR DESCRIPTION
タイトルのエラーを直しました。

webソケットのクローズのタイミングを画面遷移前に修正しました。
手元ではトーナメントも正常に開始、終了できました。