### PR TITLE
Reset login progress flag

### DIFF
--- a/frontend/static_vol/js/components/Home.js
+++ b/frontend/static_vol/js/components/Home.js
@@ -85,6 +85,7 @@ export default class LogIn extends PageBase {
         const formLogin = document.getElementById('formLogin');
         if (!formLogin.checkValidity()) {
             this.handleValidationError('loginError1');
+            this.loginInProgress = false;
             return;
         }
 


### PR DESCRIPTION
#316 

# ログイン時のフラグをリセット

- バリデーションにひっかかってそれ以上動かなくなる状態を解消

### 確認方法
1. ユーザー名に2文字のみを入れるなどフロントのバリデーションにひっかかるようにしてログインボタンを押す
2. 有効なユーザー名とパスワードを入力して正常にログインできることを確認