### PR TITLE
[fix]matchLogに自分のwinマークがつかなくなっていた

### DIFF
--- a/backend/scandamus/players/serializers.py
+++ b/backend/scandamus/players/serializers.py
@@ -135,7 +135,7 @@ class MatchLogSerializer(serializers.ModelSerializer):
 
     def get_is_win(self, obj):
         user = self.context['request'].user
-        return obj.winner == user
+        return obj.winner.user == user
 
     def get_players(self, obj):
         players_info = [

--- a/backend/scandamus/players/serializers.py
+++ b/backend/scandamus/players/serializers.py
@@ -135,7 +135,9 @@ class MatchLogSerializer(serializers.ModelSerializer):
 
     def get_is_win(self, obj):
         user = self.context['request'].user
-        return obj.winner.user == user
+        if obj.winner:
+            return obj.winner.user == user
+        return False
 
     def get_players(self, obj):
         players_info = [


### PR DESCRIPTION
DashboardのmatchLog、自分のwinマークがつかなくなっていました。
復活させました
![iswin](https://github.com/user-attachments/assets/8ffb7b5d-5555-4838-80b3-7e0f8c02ebca)
