### PR TITLE
Fix dummy match data

### DIFF
--- a/backend/scandamus/game/management/commands/gen_dummy_match.py
+++ b/backend/scandamus/game/management/commands/gen_dummy_match.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from django.contrib.auth import get_user_model
 from players.models import Player
 from game.models import Match
+from game.serializers import MatchSerializer
 import random
 
 class Command(BaseCommand):
@@ -20,21 +21,27 @@ class Command(BaseCommand):
             score1 = 10 if random.random() < 0.5 else random.randint(0, 9)
             score2 = 10 if random.random() < 0.5 else random.randint(0, 9)
 
-            Match.objects.create(
+            match = Match.objects.create(
                 game_name='pong',
                 player1=player1,
                 player2=player2,
                 score1=score1,
                 score2=score2,
-                status='after'
+                status='before'
             )
+            serializer = MatchSerializer(match, data={'status': 'after'}, partial=True)
+            if serializer.is_valid():
+                serializer.save()
+                self.stdout.write(self.style.SUCCESS(f'Successfully updated match {match.id}'))
+            else:
+                self.stdout.write(self.style.ERROR(f'Failed to update match {match.id}: {serializer.errors}'))
 
         # Create dummy matches for 'pong4' game
         for _ in range(10):
             players = random.sample(list(Player.objects.exclude(user__is_superuser=True)), 4)
             scores = [10 if random.random() < 0.5 else random.randint(0, 9) for _ in range(4)]
 
-            Match.objects.create(
+            match = Match.objects.create(
                 game_name='pong4',
                 player1=players[0],
                 player2=players[1],
@@ -44,7 +51,11 @@ class Command(BaseCommand):
                 score2=scores[1],
                 score3=scores[2],
                 score4=scores[3],
-                status='after'
+                status='before'
             )
-
-        self.stdout.write(self.style.SUCCESS('Successfully created dummy match data.'))
+            serializer = MatchSerializer(match, data={'status': 'after'}, partial=True)
+            if serializer.is_valid():
+                    serializer.save()
+                    self.stdout.write(self.style.SUCCESS(f'Successfully updated match {match.id}'))
+            else:
+                    self.stdout.write(self.style.ERROR(f'Failed to update match {match.id}: {serializer.errors}'))


### PR DESCRIPTION
ダミーのマッチデータ作成時にwinnerがセットされない問題を修正（api-internal経由以外ではupdateが発火しない）

以下の点について考慮すべき
- 現状では同点の際にwinnerがNoneになる（トーナメントのみ決定するロジックなので）
- pong4の得点があり得ない点数になっている