### PR TITLE
API error handling

### DIFF
--- a/backend/scandamus/game/consumers.py
+++ b/backend/scandamus/game/consumers.py
@@ -129,7 +129,7 @@ class LoungeSession(AsyncWebsocketConsumer):
         logger.info(f'sent online status: {online_status} of {changed_username} to {self.user.username}')
 
     async def disconnect(self, close_code):
-        if hasattr(self, 'user') and self.user.username in self.players:
+        if hasattr(self, 'user') and self.user is not None and self.user.username in self.players:
             del LoungeSession.players[self.user.username]
             await self.channel_layer.group_discard(
                 self.group_name,

--- a/backend/scandamus/scandamus/api_exception.py
+++ b/backend/scandamus/scandamus/api_exception.py
@@ -1,0 +1,29 @@
+from rest_framework.views import exception_handler
+from rest_framework.response import Response
+from rest_framework import status
+from django.http import Http404
+import logging
+
+logger = logging.getLogger(__name__)
+
+def api_exception_handler(exc, context):
+    response = exception_handler(exc, context)
+    
+    logger.error(f'Exception: {str(exc)}, Context: {context}')
+
+    if isinstance(exc, Http404):
+        return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+    if response is not None:
+        response.data = {
+            'message': response.data.get('detail', 'An error occured')
+        }
+        if 'status_code' in response.data:
+            del response.data['status_code']
+        if 'detail' in response.data:
+            del response.data['detail']        
+    else:
+        response = Response({'message': 'An unexpected error occured', 'status_code': status.HTTP_500_INTERNAL_SERVER_ERROR},
+                            status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        
+    return response

--- a/backend/scandamus/scandamus/settings.py
+++ b/backend/scandamus/scandamus/settings.py
@@ -34,7 +34,7 @@ SECRET_KEY = get_env_var('BACKEND_SECRET_KEY')
 CHANNEL_SECRET_KEY = get_env_var('CHANNEL_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = get_env_var('DEBUG')
+DEBUG = get_env_var('DEBUG').lower() in ['true', '1']
 CREATE_TOURNAMENT_TIMELIMIT_MIN = get_env_var('CREATE_TOURNAMENT_TIMELIMIT_MIN')
 FRIENDS_MAX = get_env_var('FRIENDS_MAX')
 
@@ -122,7 +122,6 @@ TEMPLATES = [
     },
 ]
 
-
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'scandamus.authentication.InternalNetworkAuthentication',
@@ -131,7 +130,11 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
-    ]
+    ],
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    ),
+    'EXCEPTION_HANDLER': 'scandamus.api_exception.api_exception_handler'
 }
 
 AUTHENTICATION_BACKENDS = (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
     volumes:
       - ./frontend/static_vol:/var/www/html
       - ${CERTS}:/etc/nginx/ssl
+      - ./backend/scandamus/static/:/var/www/static
     restart: always
     networks:
       - backend-network
@@ -81,6 +82,7 @@ services:
     container_name: pong-server
     environment:
       - PONG_LOG_LEVEL=${PONG_LOG_LEVEL}
+      - DEBUG=${DEBUG}
       - DOMAIN_NAME=${DOMAIN_NAME}
       - DB_NAME=${DB_NAME}
       - DB_USER=${DB_USER}
@@ -105,6 +107,7 @@ services:
     container_name: pong4-server
     environment:
       - PONG4_LOG_LEVEL=${PONG4_LOG_LEVEL}
+      - DEBUG=${DEBUG}
       - DOMAIN_NAME=${DOMAIN_NAME}
       - DB_NAME=${DB_NAME}
       - DB_USER=${DB_USER}

--- a/docker-compose_test.yml
+++ b/docker-compose_test.yml
@@ -57,6 +57,7 @@ services:
     volumes:
       - ./frontend/static_vol:/var/www/html
       - ${CERTS}:/etc/nginx/ssl
+      - ./backend/scandamus/static/:/var/www/static
     restart: always
     networks:
       - frontend-network
@@ -82,6 +83,7 @@ services:
     container_name: pong-server
     environment:
       - PONG_LOG_LEVEL=${PONG_LOG_LEVEL}
+      - DEBUG=${DEBUG}
       - DOMAIN_NAME=${DOMAIN_NAME}
       - DB_NAME=${DB_NAME}
       - DB_USER=${DB_USER}
@@ -106,6 +108,7 @@ services:
     container_name: pong4-server
     environment:
       - PONG4_LOG_LEVEL=${PONG4_LOG_LEVEL}
+      - DEBUG=${DEBUG}
       - DOMAIN_NAME=${DOMAIN_NAME}
       - DB_NAME=${DB_NAME}
       - DB_USER=${DB_USER}

--- a/frontend/tools/ssl.conf
+++ b/frontend/tools/ssl.conf
@@ -6,21 +6,14 @@ server {
     ssl_certificate_key /etc/nginx/ssl/server.key;
     ssl_protocols TLSv1.3;
 
-#    if ($scheme != "https") {
-#  	    return 301 https://$host$request_uri;
-#    }
     root   /var/www/html;
    
     location / {
         try_files $uri $uri/ /index.html;
     }
 
-    location /static/ {
-        proxy_pass http://backend:8001;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;        
+    location /static/uploads/avatar/ {
+        root /var/www/;
     }
 
     location /admin/ {

--- a/frontend/tools/test_ssl.conf
+++ b/frontend/tools/test_ssl.conf
@@ -6,21 +6,14 @@ server {
     ssl_certificate_key /etc/nginx/ssl/server.key;
     ssl_protocols TLSv1.3;
 
-#    if ($scheme != "https") {
-#  	    return 301 https://$host$request_uri;
-#    }
     root   /var/www/html;
    
     location / {
         try_files $uri $uri/ /index.html;
     }
 
-    location /static/ {
-        proxy_pass http://backend:8001;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;        
+    location /static/uploads/avatar/ {
+        root /var/www/;
     }
 
     location /admin/ {

--- a/pong-server/game-server/mysite/settings.py
+++ b/pong-server/game-server/mysite/settings.py
@@ -35,7 +35,7 @@ SECRET_KEY = get_env_var('SECRET_KEY')
 CHANNEL_SECRET_KEY = get_env_var('CHANNEL_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = get_env_var('DEBUG').lower() in ['true', '1']
 
 # SERVER HOST
 SERVER_HOST = get_env_var('DOMAIN_NAME')

--- a/pong4-server/game-server/mysite/settings.py
+++ b/pong4-server/game-server/mysite/settings.py
@@ -35,7 +35,7 @@ SECRET_KEY = get_env_var('SECRET_KEY')
 CHANNEL_SECRET_KEY = get_env_var('CHANNEL_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = get_env_var('DEBUG').lower() in ['true', '1']
 
 # SERVER HOST
 SERVER_HOST = get_env_var('DOMAIN_NAME')


### PR DESCRIPTION
#288 
#322 
# APIのエラーハンドリング

- REST API用に例外ハンドラーを設定
- DEBUG=Falseにした場合にクライアントにデバッグ情報が渡らないようにした
- DEBUG=Falseではavatarファイルにアクセス出来ないため、ディレクトリをfrontendにマウントしてnginxからアクセスさせるよう変更
- Null userの切断時に例外が飛ばないように変更

https://localhost/api/game/match/1/
→404

https://localhost/api/players/recommend/
→401 {"message":"Authentication credentials were not provided."}
セキュリティ的に問題のない最低限のエラー内容を返しています