### PR TITLE
[fix]avatar upload error 415は強制ログアウトさせない

### DIFF
--- a/frontend/static_vol/js/modules/labels_en.js
+++ b/frontend/static_vol/js/modules/labels_en.js
@@ -9,7 +9,8 @@ export const labels_en = {
         switchLang: 'Switch Language',
         logoutTokenExpired: 'Session expired. You have been logged out. Please log in again.',
         disconnected: 'Disconnected from the server',
-        disconnectedByNewLogin: 'Disconnected due to a new login on the server'
+        disconnectedByNewLogin: 'Disconnected due to a new login on the server',
+        failUpdateDbLang: 'Failed to save language settings',
     },
     home: {
         title: 'Home',

--- a/frontend/static_vol/js/modules/labels_fr.js
+++ b/frontend/static_vol/js/modules/labels_fr.js
@@ -9,7 +9,8 @@ export const labels_fr = {
         switchLang: 'Changer de langue',
         logoutTokenExpired: 'Session expirée. Vous avez été déconnecté. Veuillez vous reconnecter.',
         disconnected: 'Déconnecté du serveur',
-        disconnectedByNewLogin: 'Déconnecté en raison d’une nouvelle connexion sur le serveur'
+        disconnectedByNewLogin: 'Déconnecté en raison d’une nouvelle connexion sur le serveur',
+        failUpdateDbLang: 'Échec de la sauvegarde des paramètres de langue',
     },
     home: {
         title: 'Accueil',

--- a/frontend/static_vol/js/modules/labels_ja.js
+++ b/frontend/static_vol/js/modules/labels_ja.js
@@ -9,7 +9,8 @@ export const labels_ja = {
         switchLang: '言語選択',
         logoutTokenExpired: 'セッション期限が切れました。再ログインしてください。',
         disconnected: 'サーバーとの接続が切れました',
-        disconnectedByNewLogin: 'サーバーに新しいログインがあったため切断されました'
+        disconnectedByNewLogin: 'サーバーに新しいログインがあったため切断されました',
+        failUpdateDbLang: '言語設定の保存に失敗しました',
     },
     home: {
         title: 'Home',


### PR DESCRIPTION
avatarのuploadでエラーが返ってきたら強制ログアウトにしていたのですが、
token errorの場合のみログアウトさせるようにしました。

`415 Unsupported Media Type`やbad requestなどでも強制ログアウトがかかっていたのですが、これはログインしたままでも良さそうに思ったため。