### PR TITLE
Fix/fix link unprotected

### DIFF
--- a/frontend/static_vol/js/modules/router.js
+++ b/frontend/static_vol/js/modules/router.js
@@ -107,7 +107,8 @@ const router = async (accessToken) => {
         }
     } else if (flagPopState) {
         //ゲーム以外からの履歴移動
-        accessToken = getToken('accessToken');
+        const isLogin = !!sessionStorage.getItem('accessToken');
+        accessToken = isLogin ? getToken('accessToken') : false;
 
         //gameへの移動はdashboardにリダイレクト
         if (location.pathname.startsWith('/game/pong')) {

--- a/frontend/static_vol/js/modules/router.js
+++ b/frontend/static_vol/js/modules/router.js
@@ -53,7 +53,12 @@ const linkSpa = async (ev) => {
     }
     history.pushState(null, null, link);
     try {
-        await router(getToken('accessToken'));
+        const isLogin = !!sessionStorage.getItem('accessToken');
+        if (isLogin) {
+            await router(getToken('accessToken'));
+        } else {
+            await router(false);
+        }
     } catch (error) {
         console.error(error);
     }


### PR DESCRIPTION
ログインしていない状態で遷移する際にtokenエラーが発生していました。。

- ログイン
- 登録
- 登録（確認）
- 登録（完了）

の4ページについて、
- ページ内のボタンでの移動
- ブラウザの戻る/進むボタンでの移動時

にtoken errorにならないようにしました