### PR TITLE
[fix]選択言語が想定外なら即return

### DIFF
--- a/frontend/static_vol/js/main.js
+++ b/frontend/static_vol/js/main.js
@@ -32,6 +32,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         const elSelectLang = ev.target;
         const selectedLanguage = elSelectLang.value;
         const currentLang = localStorage.getItem('configLang');
+        if (selectedLanguage !== 'en' && selectedLanguage !== 'ja' && selectedLanguage !== 'fr') {
+            return;
+        }
 
         // ログイン状態判定
         const isLogin = !!sessionStorage.getItem('accessToken');


### PR DESCRIPTION
```
<select id="languageSelect">
    <option value="end" lang="en">English</option>
    <option value="<script>alert(0)</script>" lang="ja">日本語</option>
    <option value="fr" lang="fr" selected="selected">français</option>
</select>
```
とかされるとhtmlのlang属性に`<script>alert(0)</script>`や`end`が入ったりしてしまうので阻止します