### PR TITLE
[fix]42logingボタンの連打を防止

### DIFF
--- a/frontend/static_vol/js/components/Home.js
+++ b/frontend/static_vol/js/components/Home.js
@@ -185,6 +185,11 @@ export default class LogIn extends PageBase {
 
     async handleLogin42(ev) {
         ev.preventDefault();
+        //すでに処理中ならキャンセル
+        if (this.loginInProgress) {
+            return;
+        }
+        this.loginInProgress = true;
         try {
             const response = await fetch('/api/oauth42/authorize42');
             const data = await response.json();

--- a/frontend/static_vol/js/components/Home.js
+++ b/frontend/static_vol/js/components/Home.js
@@ -205,6 +205,7 @@ export default class LogIn extends PageBase {
             );
         } catch (error) {
             console.error('Failed to get authorize URL:', error);
+            this.loginInProgress = false;
         }
     }
 


### PR DESCRIPTION
42loginボタンを連打できるようになっていて、
1ブラウザで複数ログインによる掃き出しなど起こっていました。
通常のログインボタン同様、連打を防止するようにしました。
